### PR TITLE
fix: use natural sort for table numbers to fix 1,10,11,2 ordering

### DIFF
--- a/lib/sort-rows.ts
+++ b/lib/sort-rows.ts
@@ -14,9 +14,10 @@ export function sortRows<T>(
     if (typeof va === "number" && typeof vb === "number") {
       return dir === "asc" ? va - vb : vb - va;
     }
-    const sa = String(va).toLowerCase();
-    const sb = String(vb).toLowerCase();
-    const cmp = sa < sb ? -1 : sa > sb ? 1 : 0;
+    const sa = String(va);
+    const sb = String(vb);
+    // Use natural sort so table numbers like 1,2,10,11 sort correctly instead of 1,10,11,2
+    const cmp = sa.localeCompare(sb, undefined, { numeric: true, sensitivity: "base" });
     return dir === "asc" ? cmp : -cmp;
   });
 }


### PR DESCRIPTION
## Summary
Fixes #12

Table numbers sorted lexicographically (1, 10, 11, 2...) instead of numerically (1, 2, 10, 11...).

## Changes
- `lib/sort-rows.ts`: Replace manual string comparison with `localeCompare` using `{ numeric: true }` option
- This correctly handles both purely numeric table numbers (1, 2, 10) and alphanumeric ones (Patio-A, Patio-B, Table-10)

## Testing
- `1, 2, 10, 11` now sorts correctly
- Mixed alphanumeric like `Patio-A, Patio-B` also sorts correctly